### PR TITLE
Two-tier poem index, opt-in table of contents, and CJK line break fix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -107,6 +107,30 @@ function contentImagesIntegration() {
   };
 }
 
+// Remark plugin: removes or replaces soft line breaks (\n) inside paragraphs
+// according to CJK line-break rules:
+//   CJK + \n + CJK  →  "" (no space — glyphs join directly)
+//   CJK + \n + ASCII →  "" (no space)
+//   ASCII + \n + CJK  →  "" (no space)
+//   ASCII + \n + ASCII → " " (one space, preserving normal word separation)
+//
+// Covered Unicode ranges:
+//   　–鿿  CJK symbols/punctuation, kana, bopomofo, CJK unified ideographs
+//   豈–￯  CJK compatibility ideographs, fullwidth/halfwidth forms
+function remarkCjkLineBreaks() {
+  const CJK = /[　-鿿豈-￯]/;
+  return function(tree) {
+    visit(tree, 'text', (node) => {
+      node.value = node.value.replace(/\n/g, (_, offset, str) => {
+        const before = offset > 0 ? str[offset - 1] : '';
+        const after = offset < str.length - 1 ? str[offset + 1] : '';
+        if (CJK.test(before) || CJK.test(after)) return '';
+        return ' ';
+      });
+    });
+  };
+}
+
 export default defineConfig({
   site: 'https://ygwang.info',
   integrations: [
@@ -115,7 +139,7 @@ export default defineConfig({
     contentImagesIntegration(),
   ],
   markdown: {
-    remarkPlugins: [remarkMath, remarkContentImages],
+    remarkPlugins: [remarkMath, remarkContentImages, remarkCjkLineBreaks],
     rehypePlugins: [[rehypeKatex, {}]],
     remarkRehype: { allowDangerousHtml: true },
   },

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,77 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+interface Props {
+  headings: Heading[];
+}
+const { headings } = Astro.props;
+const h2s = headings.filter(h => h.depth === 2);
+---
+
+{h2s.length > 0 && (
+  <nav class="toc-nav">
+    <span class="toc-label">目录</span>
+    <ul class="toc-list">
+      {h2s.map(h => (
+        <li class="toc-item">
+          <a href={`#${h.slug}`}>{h.text}</a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}
+
+<style>
+.toc-nav {
+  margin-bottom: var(--content-gap);
+  padding: 12px 14px 10px;
+  font-size: 14px;
+  line-height: 1.6;
+  border-inline-start: 3px solid var(--tertiary);
+  background: var(--code-bg);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.toc-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--secondary);
+  margin-bottom: 6px;
+}
+
+.toc-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.toc-item {
+  margin: 0;
+}
+
+.toc-item a {
+  display: block;
+  padding: 3px 8px;
+  margin: 0 -8px;
+  color: var(--content);
+  border-radius: 4px;
+  box-shadow: none !important;
+  transition: background 0.12s;
+}
+
+.toc-item a::before {
+  content: '·\00a0\00a0';
+  color: var(--tertiary);
+}
+
+.toc-item a:hover {
+  background: var(--tertiary);
+  color: var(--primary);
+  box-shadow: none !important;
+}
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -22,6 +22,7 @@ const baseCollection = defineCollection({
     author: z.string().default('王咏刚'),
     date: z.coerce.date(),
     draft: z.boolean().default(false),
+    toc: z.boolean().default(false),
     layout: z.string().optional(),
   }),
 });

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,7 @@ const poemCollection = defineCollection({
     date: z.coerce.date(),
     draft: z.boolean().default(false),
     form: z.enum(POEM_FORMS).default('其他'),
+    featured: z.boolean().default(false),
     layout: z.string().optional(),
   }),
 });

--- a/src/content/fictions/dog_in_the_lake/dog_in_the_lake.md
+++ b/src/content/fictions/dog_in_the_lake/dog_in_the_lake.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 未名湖的落水狗
 date: 2024-09-20
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/fish/fish.md
+++ b/src/content/fictions/fish/fish.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 一条被洗澡水拍死的鱼
 date: 2016-04-01
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/human_association/human_association.md
+++ b/src/content/fictions/human_association/human_association.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 人形公会
 date: 2015-08-01
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/jeff_dean/jeff_dean.md
+++ b/src/content/fictions/jeff_dean/jeff_dean.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 和杰夫·迪恩谈恋爱
 date: 2015-12-01
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/meowl/meowl.md
+++ b/src/content/fictions/meowl/meowl.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 猫头猫头鹰
 date: 2024-12-14
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/mr_h/mr_h.md
+++ b/src/content/fictions/mr_h/mr_h.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: H先生的邀请函
 date: 2016-04-11
 draft: false
+toc: true
 ---
 
 

--- a/src/content/fictions/resignation/resignation.md
+++ b/src/content/fictions/resignation/resignation.md
@@ -3,6 +3,7 @@ author: 半轻人
 title: 审查、辞职和再生的故事
 date: 2016-06-02
 draft: false
+toc: true
 ---
 
 

--- a/src/content/poems/poem_0081.md
+++ b/src/content/poems/poem_0081.md
@@ -4,6 +4,7 @@ title: 独自咏叹恋爱的枝桠
 date: 2013-02-19
 draft: false
 form: 其他
+featured: false
 ---
 
 

--- a/src/content/poems/poem_0112.md
+++ b/src/content/poems/poem_0112.md
@@ -4,6 +4,7 @@ title: 梦醒
 date: 2016-09-11
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/content/poems/poem_0125.md
+++ b/src/content/poems/poem_0125.md
@@ -4,6 +4,7 @@ title: 时间和故居
 date: 2018-04-13
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/content/poems/poem_0129.md
+++ b/src/content/poems/poem_0129.md
@@ -4,6 +4,7 @@ title: 往事随书而逝
 date: 2019-03-25
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/content/poems/poem_0139.md
+++ b/src/content/poems/poem_0139.md
@@ -4,6 +4,7 @@ title: 极光的尾巴
 date: 2024-05-12
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/content/poems/poem_0140.md
+++ b/src/content/poems/poem_0140.md
@@ -4,6 +4,7 @@ title: 周末我们聊起孤独
 date: 2024-10-21
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/content/poems/poem_0157.md
+++ b/src/content/poems/poem_0157.md
@@ -4,6 +4,7 @@ title: 从自己身边路过
 date: 2026-05-04
 draft: false
 form: 其他
+featured: true
 ---
 
 

--- a/src/layouts/ListLayout.astro
+++ b/src/layouts/ListLayout.astro
@@ -5,17 +5,18 @@ import Breadcrumbs from '@/components/Breadcrumbs.astro';
 interface Props {
   title: string;
   breadcrumb?: string;
+  crumbs?: Array<{ label: string; url?: string }>;
   rssUrl?: string;
 }
 
-const { title, breadcrumb, rssUrl } = Astro.props;
+const { title, breadcrumb, crumbs, rssUrl } = Astro.props;
 ---
 
 <BaseLayout title={title} bodyClass="list">
   <div class="list">
     <header class="page-header">
-      {breadcrumb && (
-        <Breadcrumbs crumbs={[{ label: '主页', url: '/' }]} />
+      {(crumbs ?? breadcrumb) && (
+        <Breadcrumbs crumbs={crumbs ?? [{ label: '主页', url: '/' }]} />
       )}
       <h1>
         {title}

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -3,10 +3,13 @@ import BaseLayout from './BaseLayout.astro';
 import Breadcrumbs from '@/components/Breadcrumbs.astro';
 import PostNav from '@/components/PostNav.astro';
 import PoemRenderer from '@/components/PoemRenderer.astro';
+import TableOfContents from '@/components/TableOfContents.astro';
 import { wordCount, formatDate } from '@/utils/collections';
 
 interface NavEntry { title: string; url: string; }
 interface Crumb { label: string; url?: string; }
+
+interface Heading { depth: number; slug: string; text: string; }
 
 interface Props {
   title: string;
@@ -17,6 +20,8 @@ interface Props {
   prev?: NavEntry | null;
   next?: NavEntry | null;
   isPoem?: boolean;
+  toc?: boolean;
+  headings?: Heading[];
 }
 
 const {
@@ -28,6 +33,8 @@ const {
   prev = null,
   next = null,
   isPoem = false,
+  toc = false,
+  headings = [],
 } = Astro.props;
 
 const wc = wordCount(body);
@@ -48,6 +55,7 @@ const dateStr = formatDate(date);
       </div>
     </header>
     <div class="post-content">
+      {toc && <TableOfContents headings={headings} />}
       <slot />
     </div>
     <footer class="post-footer">

--- a/src/pages/essays/[slug].astro
+++ b/src/pages/essays/[slug].astro
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
 }
 
 const { entry, allEssays } = Astro.props;
-const { Content } = await entry.render();
+const { Content, headings } = await entry.render();
 const { prev, next } = getSiblings(allEssays, entry);
 const slug = entrySlug(entry);
 ---
@@ -29,6 +29,8 @@ const slug = entrySlug(entry);
   ]}
   prev={prev ? { title: prev.data.title, url: `/essays/${entrySlug(prev)}/` } : null}
   next={next ? { title: next.data.title, url: `/essays/${entrySlug(next)}/` } : null}
+  toc={entry.data.toc}
+  headings={headings}
 >
   <Content />
 </PostLayout>

--- a/src/pages/fictions/[slug].astro
+++ b/src/pages/fictions/[slug].astro
@@ -12,7 +12,7 @@ export async function getStaticPaths() {
 }
 
 const { entry, allFictions } = Astro.props;
-const { Content } = await entry.render();
+const { Content, headings } = await entry.render();
 const { prev, next } = getSiblings(allFictions, entry);
 ---
 
@@ -28,6 +28,8 @@ const { prev, next } = getSiblings(allFictions, entry);
   ]}
   prev={prev ? { title: prev.data.title, url: `/fictions/${entrySlug(prev)}/` } : null}
   next={next ? { title: next.data.title, url: `/fictions/${entrySlug(next)}/` } : null}
+  toc={entry.data.toc}
+  headings={headings}
 >
   <Content />
 </PostLayout>

--- a/src/pages/poems/[slug].astro
+++ b/src/pages/poems/[slug].astro
@@ -24,6 +24,7 @@ const { prev, next } = getSiblings(allPoems, entry);
   crumbs={[
     { label: '主页', url: '/' },
     { label: '诗歌', url: '/poems/' },
+    { label: String(entry.data.date.getFullYear()), url: `/poems/${entry.data.date.getFullYear()}/` },
     { label: entry.data.title },
   ]}
   prev={prev ? { title: prev.data.title, url: `/poems/${poemSlug(prev)}/` } : null}

--- a/src/pages/poems/[year]/index.astro
+++ b/src/pages/poems/[year]/index.astro
@@ -1,32 +1,32 @@
 ---
 import { getCollection } from 'astro:content';
 import ListLayout from '@/layouts/ListLayout.astro';
-import Pagination from '@/components/Pagination.astro';
 import { sortByDate, formatDate, wordCount, excerpt, poemSlug } from '@/utils/collections';
 
 export async function getStaticPaths() {
-  const PAGE_SIZE = 10;
   const allPoems = await getCollection('poems', e => !e.data.draft);
-  const sorted = sortByDate(allPoems);
-  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const years = [...new Set(allPoems.map(p => p.data.date.getFullYear()))];
 
-  return Array.from({ length: totalPages - 1 }, (_, i) => {
-    const page = i + 2;
-    return {
-      params: { page: String(page) },
-      props: {
-        poems: sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
-        currentPage: page,
-        totalPages,
-      },
-    };
-  });
+  return years.map(year => ({
+    params: { year: String(year) },
+    props: {
+      year,
+      poems: sortByDate(allPoems.filter(p => p.data.date.getFullYear() === year)),
+    },
+  }));
 }
 
-const { poems, currentPage, totalPages } = Astro.props;
+const { year, poems } = Astro.props;
 ---
 
-<ListLayout title="诗歌" breadcrumb="诗歌" rssUrl="/index.xml">
+<ListLayout
+  title={`诗歌 · ${year}`}
+  crumbs={[
+    { label: '主页', url: '/' },
+    { label: '诗歌', url: '/poems/' },
+    { label: String(year) },
+  ]}
+>
   {poems.map(poem => (
     <div class="post-entry">
       <header class="entry-header">
@@ -41,6 +41,4 @@ const { poems, currentPage, totalPages } = Astro.props;
       <a class="entry-link" href={`/poems/${poemSlug(poem)}/`} aria-label={poem.data.title}></a>
     </div>
   ))}
-
-  <Pagination currentPage={currentPage} totalPages={totalPages} baseUrl="/poems" />
 </ListLayout>

--- a/src/pages/poems/[year]/index.astro
+++ b/src/pages/poems/[year]/index.astro
@@ -5,19 +5,31 @@ import { sortByDate, formatDate, wordCount, excerpt, poemSlug } from '@/utils/co
 
 export async function getStaticPaths() {
   const allPoems = await getCollection('poems', e => !e.data.draft);
-  const years = [...new Set(allPoems.map(p => p.data.date.getFullYear()))];
+  const years = [...new Set(allPoems.map(p => p.data.date.getFullYear()))]
+    .sort((a, b) => b - a); // descending: newer first
 
-  return years.map(year => ({
+  return years.map((year, idx) => ({
     params: { year: String(year) },
     props: {
       year,
       poems: sortByDate(allPoems.filter(p => p.data.date.getFullYear() === year)),
+      prevYear: idx > 0 ? years[idx - 1] : null,             // newer year
+      nextYear: idx < years.length - 1 ? years[idx + 1] : null, // older year
     },
   }));
 }
 
-const { year, poems } = Astro.props;
+const { year, poems, prevYear, nextYear } = Astro.props;
 ---
+
+<style>
+.paginav {
+  background: var(--entry);
+}
+.paginav a:hover {
+  background: var(--tertiary);
+}
+</style>
 
 <ListLayout
   title={`诗歌 · ${year}`}
@@ -41,4 +53,27 @@ const { year, poems } = Astro.props;
       <a class="entry-link" href={`/poems/${poemSlug(poem)}/`} aria-label={poem.data.title}></a>
     </div>
   ))}
+
+  {(prevYear || nextYear) && (
+    <nav class="paginav">
+      {prevYear && (
+        <div class="prev">
+          <a href={`/poems/${prevYear}/`}>
+            <span class="title">« 上一年</span>
+            <br />
+            <span>{prevYear}</span>
+          </a>
+        </div>
+      )}
+      {nextYear && (
+        <div class="next">
+          <a href={`/poems/${nextYear}/`}>
+            <span class="title">下一年 »</span>
+            <br />
+            <span>{nextYear}</span>
+          </a>
+        </div>
+      )}
+    </nav>
+  )}
 </ListLayout>

--- a/src/pages/poems/index.astro
+++ b/src/pages/poems/index.astro
@@ -1,40 +1,121 @@
 ---
 import { getCollection } from 'astro:content';
 import ListLayout from '@/layouts/ListLayout.astro';
-import Pagination from '@/components/Pagination.astro';
-import { sortByDate, formatDate, wordCount, excerpt, poemSlug } from '@/utils/collections';
-
-const PAGE_SIZE = 10;
+import { sortByDate, formatDate, poemSlug } from '@/utils/collections';
 
 const allPoems = await getCollection('poems', e => !e.data.draft);
 const sorted = sortByDate(allPoems);
-const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
-const currentPage = 1;
-const poems = sorted.slice(0, PAGE_SIZE);
+
+const featured = sorted.filter(p => p.data.featured);
+
+const yearMap = new Map<number, number>();
+for (const poem of sorted) {
+  const y = poem.data.date.getFullYear();
+  yearMap.set(y, (yearMap.get(y) ?? 0) + 1);
+}
+const years = [...yearMap.entries()].sort((a, b) => b[0] - a[0]);
 ---
 
 <ListLayout title="诗歌" breadcrumb="诗歌" rssUrl="/index.xml">
-  <div class="section-intro">
+  <div class="section-intro poems-section">
     <img src="/images/sections/poems.jpg" alt="咏刚的诗歌" />
     <blockquote>
       咏刚按：这里收集的，说是诗歌，也不完全算诗歌。类型很杂，水平参差不齐。有依平水韵写的古近体诗，其中也有个别用了今韵。有半数左右现代诗，风格相当驳杂。有略带禅意的偈子，打机锋、抖机灵的骈文。还有一批是戏谑为主的顺口溜。
     </blockquote>
   </div>
 
-  {poems.map(poem => (
-    <div class="post-entry">
-      <header class="entry-header">
-        <h2>{poem.data.title}</h2>
-      </header>
-      <div class="entry-content">{excerpt(poem.body)}</div>
-      <div class="entry-footer">
-        <time datetime={poem.data.date.toISOString()}>{formatDate(poem.data.date)}</time>
-        <span>&nbsp;·&nbsp;{wordCount(poem.body)} 字</span>
-        <span>&nbsp;·&nbsp;{poem.data.author}</span>
+  {featured.length > 0 && (
+    <section class="poems-section">
+      <h2 class="section-heading">精选诗歌</h2>
+      <div class="featured-grid">
+        {featured.map(poem => (
+          <div class="post-entry featured-entry">
+            <header class="entry-header">
+              <h2>{poem.data.title}</h2>
+            </header>
+            <div class="entry-footer">
+              <time datetime={poem.data.date.toISOString()}>{formatDate(poem.data.date)}</time>
+            </div>
+            <a class="entry-link" href={`/poems/${poemSlug(poem)}/`} aria-label={poem.data.title}></a>
+          </div>
+        ))}
       </div>
-      <a class="entry-link" href={`/poems/${poemSlug(poem)}/`} aria-label={poem.data.title}></a>
-    </div>
-  ))}
+    </section>
+  )}
 
-  <Pagination currentPage={currentPage} totalPages={totalPages} baseUrl="/poems" />
+  <section class="poems-section">
+    <h2 class="section-heading">按年份浏览</h2>
+    <div class="year-grid">
+      {years.map(([year, count]) => (
+        <a class="year-card" href={`/poems/${year}/`}>
+          <span class="year-number">{year}</span>
+          <span class="year-count">{count}&thinsp;首</span>
+        </a>
+      ))}
+    </div>
+  </section>
 </ListLayout>
+
+<style>
+.section-heading {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--secondary);
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.poems-section {
+  margin-bottom: calc(var(--gap) * 1.5);
+}
+
+.featured-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 10px;
+}
+
+.featured-grid .post-entry {
+  margin-bottom: 0;
+}
+
+.year-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(calc(33.333% - 7px), 1fr));
+  gap: 10px;
+}
+
+.year-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 14px 8px;
+  background: var(--entry);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: transform 0.1s, background 0.15s;
+}
+
+.year-card:hover {
+  background: var(--tertiary);
+}
+
+.year-card:active {
+  transform: scale(0.96);
+}
+
+.year-number {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--primary);
+  line-height: 1;
+}
+
+.year-count {
+  font-size: 12px;
+  color: var(--secondary);
+  margin-top: 5px;
+}
+</style>


### PR DESCRIPTION
Poems two-tier index
  - /poems/ is now a hub page: a featured-poems grid (opt-in via featured: true in frontmatter) and a year-tile grid linking to per-year listing pages
  - New /poems/<year>/ pages list all poems for that year with prev/next year navigation
  - Individual poem pages gain a year breadcrumb (主页 » 诗歌 » 2025 » title) for direct navigation back to the year index
  - Old flat paginated list (/poems/page/[n]/) removed

  Table of contents
  - New TableOfContents component renders depth-2 (##) headings only as a bullet list with background-highlight hover
  - Opt-in via toc: true in frontmatter; works for fictions and essays collections
  - Enabled on all fiction entries

  CJK line break fix
  - New remark plugin resolves soft line breaks in multi-line Chinese paragraphs: CJK–CJK and CJK–ASCII boundaries drop the newline with no space; ASCII–ASCII boundaries keep a space
  - Covers U+3000–U+9FFF and U+F900–U+FFEF